### PR TITLE
Fix java 10 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.0.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,17 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
 
             </plugin>
+	<plugin>
+	    <groupId>org.apache.maven.plugins</groupId>
+	    <artifactId>maven-compiler-plugin</artifactId>
+	    <dependencies>
+		<dependency>
+		    <groupId>org.ow2.asm</groupId>
+		    <artifactId>asm</artifactId>
+		    <version>6.2</version>
+		</dependency>
+	    </dependencies>
+	</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
 Fixes java 10 build by upgrading the ASM (from the maven compiler plugin) to a version that supports java 10.
 Also took the oportunity to upgrade to the latest spring boot version. (I can squash or remove this commit from the PR if requested)